### PR TITLE
chore: bump go-ethereum to 1.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/bytecodealliance/wasmtime-go/v9 v9.0.0
-	github.com/ethereum/go-ethereum v1.11.6
+	github.com/ethereum/go-ethereum v1.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/bytecodealliance/wasmtime-go/v9 v9.0.0/go.mod h1:zpOxt1j5vj44AzXZVhS4
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ethereum/go-ethereum v1.11.6 h1:2VF8Mf7XiSUfmoNOy3D+ocfl9Qu8baQBrCNbo2CXQ8E=
-github.com/ethereum/go-ethereum v1.11.6/go.mod h1:+a8pUj1tOyJ2RinsNQD4326YS+leSoKGiG/uVVb0x6Y=
+github.com/ethereum/go-ethereum v1.12.0 h1:bdnhLPtqETd4m3mS8BGMNvBTf36bO5bx/hxE2zljOa0=
+github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c h1:DZfsyhDK1hnSS5lH8l+JggqzEleHteTYfutAiVlSUM8=

--- a/register.go
+++ b/register.go
@@ -9,13 +9,13 @@ import (
 
 type (
 	Module     string
-	Namesapce  string
+	NameSpace  string
 	MethodName string
 )
 
 type HostAPIRegistry struct {
-	// a function defined in Module::Namesapce::MethodName
-	wrapperFuncs map[Module]map[Namesapce]map[MethodName]interface{}
+	// a function defined in Module::Namespace::MethodName
+	wrapperFuncs map[Module]map[NameSpace]map[MethodName]interface{}
 
 	logger log.Logger
 	ctx    *rtypes.Context
@@ -23,19 +23,19 @@ type HostAPIRegistry struct {
 
 func NewHostAPIRegistry() *HostAPIRegistry {
 	return &HostAPIRegistry{
-		wrapperFuncs: make(map[Module]map[Namesapce]map[MethodName]interface{}, 0),
+		wrapperFuncs: make(map[Module]map[NameSpace]map[MethodName]interface{}, 0),
 		ctx:          rtypes.NewContext(context.Background(), nil),
 	}
 }
 
-func (h *HostAPIRegistry) AddApi(module Module, ns Namesapce, method MethodName, fn interface{}) error {
+func (h *HostAPIRegistry) AddApi(module Module, ns NameSpace, method MethodName, fn interface{}) error {
 	wrapper, err := Wrappers(h.ctx, fn)
 	if err != nil {
 		return err
 	}
 
 	if h.wrapperFuncs[module] == nil {
-		h.wrapperFuncs[module] = make(map[Namesapce]map[MethodName]interface{}, 1)
+		h.wrapperFuncs[module] = make(map[NameSpace]map[MethodName]interface{}, 1)
 	}
 
 	if h.wrapperFuncs[module][ns] == nil {
@@ -46,7 +46,7 @@ func (h *HostAPIRegistry) AddApi(module Module, ns Namesapce, method MethodName,
 	return nil
 }
 
-func (h *HostAPIRegistry) WrapperFuncs() map[Module]map[Namesapce]map[MethodName]interface{} {
+func (h *HostAPIRegistry) WrapperFuncs() map[Module]map[NameSpace]map[MethodName]interface{} {
 	return h.wrapperFuncs
 }
 

--- a/types/basic.go
+++ b/types/basic.go
@@ -11,7 +11,7 @@ var (
 	_ IType = (*String)(nil)
 )
 
-// ByteArrary implements IType
+// ByteArray implements IType
 type ByteArray struct {
 	TypeHeader
 

--- a/wasmtime.go
+++ b/wasmtime.go
@@ -224,7 +224,7 @@ func defaultWASMTimeConfig() *wasmtime.Config {
 	return config
 }
 
-func buildModuleMethod(ns Namesapce, method MethodName) string {
+func buildModuleMethod(ns NameSpace, method MethodName) string {
 	return fmt.Sprintf("%s.%s", ns, method)
 }
 


### PR DESCRIPTION
for new cosmos sdk