### PR TITLE
fix: bump wasmtime to v14.0.0 & wasmTimeRuntime destory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/artela-network/aspect-runtime
 go 1.20
 
 require (
-	github.com/bytecodealliance/wasmtime-go/v9 v9.0.0
+	github.com/bytecodealliance/wasmtime-go/v14 v14.0.0
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bytecodealliance/wasmtime-go/v9 v9.0.0 h1:lkyiPbbo++bSmDyJVxDQwxxaiu3LOFVm0iBHnTS1W5A=
-github.com/bytecodealliance/wasmtime-go/v9 v9.0.0/go.mod h1:zpOxt1j5vj44AzXZVhS4H+hr39vMk4hDlyC42kGksbU=
+github.com/bytecodealliance/wasmtime-go/v14 v14.0.0 h1:ur7S3P+PAeJmgllhSrKnGQOAmmtUbLQxb/nw2NZiaEM=
+github.com/bytecodealliance/wasmtime-go/v14 v14.0.0/go.mod h1:tqOVEUjnXY6aGpSfM9qdVRR6G//Yc513fFYUdzZb/DY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/types/basic.go
+++ b/types/basic.go
@@ -261,7 +261,7 @@ func (i *Int64) Set(value interface{}) error {
 	if !ok {
 		return errors.New("value is not bool")
 	}
-	i.dataLen = 4
+	i.dataLen = 8
 	i.body = data
 	return nil
 }

--- a/wasmtime.go
+++ b/wasmtime.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/bytecodealliance/wasmtime-go/v9"
+	"github.com/bytecodealliance/wasmtime-go/v14"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/pkg/errors"
 
@@ -145,6 +145,15 @@ func (w *wasmTimeRuntime) ResetStore(apis *HostAPIRegistry) (err error) {
 func (w *wasmTimeRuntime) Destroy() {
 	w.apis.SetMemory(nil)
 	w.apis = nil
+
+	// The presence of ctx will impede the finalization of w.
+	w.ctx = nil
+
+	// Deallocate resources associated with the instance, linker, and store.
+	// These components will be reconstructed before the next invocation.
+	w.instance = nil
+	w.linker = nil
+	w.store = nil
 }
 
 func (w *wasmTimeRuntime) linkToHostFns() error {

--- a/wrapper.go
+++ b/wrapper.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/bytecodealliance/wasmtime-go/v9"
+	"github.com/bytecodealliance/wasmtime-go/v14"
 
 	"github.com/pkg/errors"
 


### PR DESCRIPTION
1. fix memory leak after running wasm bytecode.
2. fix the incorrect length of int64 written in memory.